### PR TITLE
fix: `SparsePauliOp.to_dict(decimals= 3)` does not return rounded res…

### DIFF
--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -400,7 +400,7 @@ class QuantumState:
 
         # Make dict of tuples
         if string_labels:
-            return dict(zip(kets, vec[inds]))
+            return dict(zip(kets, vals[inds]))
 
         return {tuple(ket): val for ket, val in zip(kets, vals[inds])}
 


### PR DESCRIPTION
This PR corrects a typo in `quantum_state.py` that prevents `SparsePauliOp.to_dict(decimals= x)` from properly returning rounded numbers  